### PR TITLE
Bugfix: Loads gtc module

### DIFF
--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -532,7 +532,7 @@ eap [% key -%] {
 	leap {
 	}
 
-[% ELSIF eaptype == "LEAP" %]
+[% ELSIF eaptype == "GTC" %]
 	#  Generic Token Card.
 	#
 	#  Currently, this is only permitted inside of EAP-TTLS,


### PR DESCRIPTION
GTC freeradius module was not getting loaded

# Description
Bugfix.
GTC module is currently not being loaded because the elsif checks for the wrong value, (it used to be GTC). The conf file checks for what I guess is the wrong key (LEAP instead of GTC, it used to be GTC). The now double check for LEAP seems to make gtc never loaded

# Issue
fixes #5644

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ n/a ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features

## Enhancements

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
GTC freeradius module not loading after upgrade #5644
